### PR TITLE
Fix up naming in jUnit XML reports

### DIFF
--- a/launch_testing/launch_testing/junitxml.py
+++ b/launch_testing/launch_testing/junitxml.py
@@ -27,24 +27,26 @@ def unittestResultsToXml(*, name='launch_test', test_results={}):
     # were active, and one from tests that ran after processes were shut down
     test_suites = ET.Element('testsuites')
     test_suites.set('name', name)
-    # test_suites.set('time', ????) skipping 'time' attribute
 
     # To get tests, failures, and errors, we just want to iterate the results once
     tests = 0
     failures = 0
     errors = 0
+    time = 0
 
     for result in test_results.values():
         tests += result.testsRun
         failures += len(result.failures)
         errors += len(result.errors)
+        time += sum(result.testTimes.values())
 
     test_suites.set('tests', str(tests))
     test_suites.set('failures', str(failures))
     test_suites.set('errors', str(errors))
+    test_suites.set('time', str(round(time, 3)))
 
-    for (key, value) in test_results.items():
-        test_suites.append(unittestResultToXml(str(key), value))
+    for (name, test_result) in test_results.items():
+        test_suites.append(unittestResultToXml(str(name), test_result))
 
     return ET.ElementTree(test_suites)
 

--- a/launch_testing/launch_testing/junitxml.py
+++ b/launch_testing/launch_testing/junitxml.py
@@ -83,7 +83,8 @@ def unittestCaseToXml(test_result, test_case):
     class needs to be a launch_testing.TestResult class
     """
     case_xml = ET.Element('testcase')
-    case_xml.set('classname', type(test_case).__name__)
+    full_classname = type(test_case).__module__ + '.' + type(test_case).__name__
+    case_xml.set('classname', full_classname)
     case_xml.set('name', test_case._testMethodName)
     case_xml.set('time', str(round(test_result.testTimes[test_case], 3)))
 

--- a/launch_testing/launch_testing/launch_test.py
+++ b/launch_testing/launch_testing/launch_test.py
@@ -73,6 +73,12 @@ def main():
         help='write junit XML style report to specified path'
     )
 
+    parser.add_argument(
+        '--test-name',
+        action='store',
+        default=None,
+        help='a name for the test'
+    )
     args = parser.parse_args()
 
     if args.verbose:
@@ -93,6 +99,8 @@ def main():
 
     args.test_file = os.path.abspath(args.test_file)
     test_module = _load_python_file_as_module(args.test_file)
+    if not args.test_name:
+        args.test_name = os.path.splitext(os.path.basename(args.test_file))[0]
 
     _logger_.debug('Checking for generate_test_description')
     if not hasattr(test_module, 'generate_test_description'):
@@ -102,7 +110,7 @@ def main():
 
     # This is a list of TestRun objects.  Each run corresponds to one launch.  There may be
     # multiple runs if the launch is parametrized
-    test_runs = LoadTestsFromPythonModule(test_module)
+    test_runs = LoadTestsFromPythonModule(test_module, name=args.test_name + '.launch_tests')
 
     # The runner handles sequcing the launches
     runner = LaunchTestRunner(
@@ -130,7 +138,7 @@ def main():
         _logger_.debug('Done running integration test')
 
         if args.xmlpath:
-            xml_report = unittestResultsToXml(test_results=results)
+            xml_report = unittestResultsToXml(test_results=results, name=args.test_name)
             xml_report.write(args.xmlpath, encoding='utf-8', xml_declaration=True)
 
         # There will be one result for every test run (see above where we load the tests)

--- a/launch_testing/launch_testing/launch_test.py
+++ b/launch_testing/launch_testing/launch_test.py
@@ -27,10 +27,10 @@ from .test_runner import LaunchTestRunner
 _logger_ = logging.getLogger(__name__)
 
 
-def _load_python_file_as_module(python_file_path):
+def _load_python_file_as_module(test_module_name, python_file_path):
     """Load a given Python launch file (by path) as a Python module."""
     # Taken from launch_testing to not introduce a weird dependency thing
-    loader = SourceFileLoader('python_launch_file', python_file_path)
+    loader = SourceFileLoader(test_module_name, python_file_path)
     return loader.load_module()
 
 
@@ -98,7 +98,7 @@ def main():
         parser.error("Test file '{}' does not exist".format(args.test_file))
 
     args.test_file = os.path.abspath(args.test_file)
-    test_module = _load_python_file_as_module(args.test_file)
+    test_module = _load_python_file_as_module(args.test_name, args.test_file)
     if not args.test_name:
         args.test_name = os.path.splitext(os.path.basename(args.test_file))[0]
 

--- a/launch_testing/launch_testing/launch_test.py
+++ b/launch_testing/launch_testing/launch_test.py
@@ -131,7 +131,7 @@ def main():
 
         if args.xmlpath:
             xml_report = unittestResultsToXml(test_results=results)
-            xml_report.write(args.xmlpath, xml_declaration=True)
+            xml_report.write(args.xmlpath, encoding='utf-8', xml_declaration=True)
 
         # There will be one result for every test run (see above where we load the tests)
         for result in results.values():

--- a/launch_testing/launch_testing/loader.py
+++ b/launch_testing/launch_testing/loader.py
@@ -34,11 +34,12 @@ def _normalize_ld(launch_description_fn):
 class TestRun:
 
     def __init__(self,
+                 name,
                  test_description_function,
                  param_args,
                  pre_shutdown_tests,
                  post_shutdown_tests):
-
+        self.name = name
         self.test_description_function = test_description_function
         self.normalized_test_description = _normalize_ld(test_description_function)
 
@@ -81,13 +82,12 @@ class TestRun:
         yield from _iterate_tests_in_test_suite(self.post_shutdown_tests)
 
     def __str__(self):
-        if not self.param_args:
-            return 'launch'
-        else:
-            return 'TODO Parametrize'
+        if self.param_args:
+            return self.name + '[some_parameter]'
+        return self.name
 
 
-def LoadTestsFromPythonModule(module):
+def LoadTestsFromPythonModule(module, *, name='launch_tests'):
 
     if hasattr(module.generate_test_description, '__parametrized__'):
         normalized_test_description_func = module.generate_test_description
@@ -96,7 +96,8 @@ def LoadTestsFromPythonModule(module):
 
     # If our test description is parameterized, we'll load a set of tests for each
     # individual launch
-    return [TestRun(description,
+    return [TestRun(name,
+                    description,
                     args,
                     PreShutdownTestLoader().loadTestsFromModule(module),
                     PostShutdownTestLoader().loadTestsFromModule(module))

--- a/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
+++ b/launch_testing/test/launch_testing/test_launch_test_runner_validation.py
@@ -24,6 +24,7 @@ class TestLaunchTestRunnerValidation(unittest.TestCase):
 
         dut = LaunchTestRunner(
             [TR(
+                '',
                 test_description_function=lambda: None,
                 param_args={},
                 pre_shutdown_tests=None,
@@ -36,6 +37,7 @@ class TestLaunchTestRunnerValidation(unittest.TestCase):
 
         dut = LaunchTestRunner(
             [TR(
+                '',
                 test_description_function=lambda ready_fn: None,
                 param_args={},
                 pre_shutdown_tests=None,

--- a/launch_testing/test/launch_testing/test_runner_results.py
+++ b/launch_testing/test/launch_testing/test_runner_results.py
@@ -52,7 +52,7 @@ def test_dut_that_shuts_down(capsys):
 
     with mock.patch('launch_testing.test_runner._RunnerWorker._run_test'):
         runner = LaunchTestRunner(
-            [TR(generate_test_description, {}, [], [])]
+            [TR('', generate_test_description, {}, [], [])]
         )
 
         results = runner.run()
@@ -99,7 +99,7 @@ def test_dut_that_has_exception(capsys):
 
     with mock.patch('launch_testing.test_runner._RunnerWorker._run_test'):
         runner = LaunchTestRunner(
-            [TR(generate_test_description, {}, [], [])]
+            [TR('', generate_test_description, {}, [], [])]
         )
 
         results = runner.run()

--- a/launch_testing/test/launch_testing/test_xml_output.py
+++ b/launch_testing/test/launch_testing/test_xml_output.py
@@ -50,6 +50,7 @@ class TestGoodXmlOutput(unittest.TestCase):
                 'launch_test',
                 path,
                 '--junit-xml', os.path.join(cls.tmpdir.name, 'junit.xml'),
+                '--test-name', 'good_proc'
             ],
         ).returncode
 
@@ -65,7 +66,7 @@ class TestGoodXmlOutput(unittest.TestCase):
         test_suite = root[0]
 
         # Expecting an element called 'launch' since this was not parametrized
-        self.assertEqual(test_suite.attrib['name'], 'launch')
+        self.assertEqual(test_suite.attrib['name'], 'good_proc.launch_tests')
 
         # Drilling down a little further, we expect the class names to show up in the testcase
         # names
@@ -173,12 +174,14 @@ class TestXmlFunctions(unittest.TestCase):
 
     def test_result_that_ran(self):
         """
-        # The expected XML output for this test looks like this
-        # <testsuites>
-        #   <testsuite name="run1" . . . >
-        #     <testcase classname="TestHost" name="test_0" . . . />
-        #   </testsuite>
-        # <testsuites>
+        Test we have output as a result of a test being run.
+
+        The expected XML output for this test is:
+        <testsuites>
+          <testsuite name="run1" . . . >
+            <testcase classname="TestHost" name="test_0" . . . />
+          </testsuite>
+        <testsuites>
         """
         # This mostly validates the test setup is good for the other tests
         dut_xml = unittestResultsToXml(
@@ -202,7 +205,9 @@ class TestXmlFunctions(unittest.TestCase):
 
     def test_result_with_skipped_test(self):
         """
-        The expected XML output for this test looks like:
+        Test we have output as a result of a skipped test.
+
+        The expected XML output for this test is:
         <testsuites>
           <testsuite name="run1" skipped="1". . . >
             <testcase classname="TestHost" name="test_0" . . . >
@@ -210,6 +215,7 @@ class TestXmlFunctions(unittest.TestCase):
             </testcase>
           </testsuite>
         <testsuites>
+
         Notice the extra 'skipped' child-element of testcase.
         """
         @unittest.skip('My reason is foo')
@@ -224,7 +230,6 @@ class TestXmlFunctions(unittest.TestCase):
             }
         )
 
-
         testsuites_element = dut_xml.getroot()
         testsuite_element = testsuites_element.find('testsuite')
         testcase_element = testsuite_element.find('testcase')
@@ -235,7 +240,10 @@ class TestXmlFunctions(unittest.TestCase):
 
     def test_result_with_failure(self):
         """
-        The expected XML output for this test is
+        Test we have output as a result of failed test.
+
+        The expected XML output for this test is:
+
         <testsuites>
           <testsuite name="run1" failures="1". . . >
             <testcase classname="TestHost" name="test_0" . . . >
@@ -246,9 +254,8 @@ class TestXmlFunctions(unittest.TestCase):
         <testsuites>
 
         Notice there's a failure message child-element of the testcase and
-        a count of failed tests
+        a count of failed tests.
         """
-
         def test_that_fails(self):
             assert 1 == 2
 
@@ -270,7 +277,10 @@ class TestXmlFunctions(unittest.TestCase):
 
     def test_result_with_error(self):
         """
+        Test we have output as a result of an error in a test.
+
         The expected XML output for this test is:
+
         <testsuites>
           <testsuite name="run1" errors="1". . . >
             <testcase classname="TestHost" name="test_0" . . . >
@@ -281,9 +291,8 @@ class TestXmlFunctions(unittest.TestCase):
         <testsuites>
 
         Python unittest treats exceptions other than AssertionError exceptions
-        as 'errors' not failures so they get a different tag, and count
+        as 'errors' not failures so they get a different tag, and count.
         """
-
         def test_that_errors(self):
             raise Exception('This is an error')
 

--- a/launch_testing_ament_cmake/cmake/add_launch_test.cmake
+++ b/launch_testing_ament_cmake/cmake/add_launch_test.cmake
@@ -97,6 +97,7 @@ function(add_launch_test file)
     string(REPLACE "/" "_" _add_launch_test_TARGET ${_add_launch_test_TARGET})
   endif()
 
+  set(test_name "${PROJECT_NAME}.${_add_launch_test_TARGET}")
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${_add_launch_test_TARGET}.xunit.xml")
 
   set(cmd
@@ -106,6 +107,7 @@ function(add_launch_test file)
     "${_file_name}"
     "${_add_launch_test_ARGS}"
     "--junit-xml=${result_file}"
+    "--test-name=${test_name}"
   )
 
   ament_add_test(

--- a/launch_testing_ament_cmake/cmake/add_launch_test.cmake
+++ b/launch_testing_ament_cmake/cmake/add_launch_test.cmake
@@ -97,7 +97,6 @@ function(add_launch_test file)
     string(REPLACE "/" "_" _add_launch_test_TARGET ${_add_launch_test_TARGET})
   endif()
 
-  set(test_name "${PROJECT_NAME}.${_add_launch_test_TARGET}")
   set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${_add_launch_test_TARGET}.xunit.xml")
 
   set(cmd
@@ -107,7 +106,7 @@ function(add_launch_test file)
     "${_file_name}"
     "${_add_launch_test_ARGS}"
     "--junit-xml=${result_file}"
-    "--test-name=${test_name}"
+    "--package-name=${PROJECT_NAME}"
   )
 
   ament_add_test(


### PR DESCRIPTION
Precisely what the title says.